### PR TITLE
Do not fork all children at the same time

### DIFF
--- a/lib/sidekiq/pool/cli.rb
+++ b/lib/sidekiq/pool/cli.rb
@@ -18,12 +18,17 @@ module Sidekiq
 
         trap_signals
 
-        @pool_size.times { fork_child }
+        @pool_size.times do
+          sleep @fork_wait || DEFAULT_FORK_WAIT
+          fork_child
+        end
 
         wait_for_signals
       end
 
       private
+
+      DEFAULT_FORK_WAIT = 1
 
       def parse_options(argv)
         opts = {}
@@ -64,6 +69,10 @@ module Sidekiq
 
           o.on "-v", "--verbose", "Print more verbose output" do |arg|
             opts[:verbose] = arg
+          end
+
+          o.on '-w', '--fork-wait NUM', "seconds to wait between child forks, default #{DEFAULT_FORK_WAIT}" do |arg|
+            @fork_wait = Integer(arg)
           end
 
           o.on '-C', '--config PATH', "path to YAML config file" do |arg|

--- a/lib/sidekiq/pool/version.rb
+++ b/lib/sidekiq/pool/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Pool
-    VERSION = '0.1.4'
+    VERSION = '0.1.5'
   end
 end


### PR DESCRIPTION
Reduce resouce pressure when spawning multiple childs

@laurynas, what do you think?

That would be first part of this: https://trello.com/c/GfUri8Fh/173-reduce-sidekiq-inactive-period-on-deploy-7-minutes-of-inactivity-during-deploy-restart