### PR TITLE
Add graceful sidekiq pool reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Start pool with a non-default path config
 
 Signals `USR1`, `USR2` are forwarded to the children.
 
+Signal `HUP` to parent starts new children and then stops old.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/laurynas/sidekiq-pool.

--- a/lib/sidekiq/pool/version.rb
+++ b/lib/sidekiq/pool/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Pool
-    VERSION = '1.0.2'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
@laurynas 

Adding graceful sidekiq-pool reload using SIGHUP signal.

1. SIGHUP is sent to parent (sidekiq-pool) process
2. Parent process sends USR1 to old sidekiq pool (telling it will shut down in near future https://github.com/mperham/sidekiq/wiki/Signals#usr1)
3. Starting new pool
4. Stopping old pool