### PR TITLE
Make USR1 signal to pool optional

### DIFF
--- a/lib/sidekiq/pool/cli.rb
+++ b/lib/sidekiq/pool/cli.rb
@@ -124,6 +124,10 @@ module Sidekiq
             @wait_until_child_loaded = Integer(arg)
           end
 
+          o.on '--suspend-before-graceful-reload', "Send USR1 singal to old pool when doing graceful reload" do |arg|
+            @suspend_before_graceful_reload = arg
+          end
+
           o.on '-V', '--version', "Print version and exit" do |arg|
             puts "Sidekiq #{Sidekiq::VERSION}"
             die(0)
@@ -212,7 +216,7 @@ module Sidekiq
 
           # Signal old pool
           # USR1 tells Sidekiq it will be shutting down in near future.
-          signal_to_pool('USR1')
+          signal_to_pool('USR1') if @suspend_before_graceful_reload
 
           # Reset pool
           @pool = []

--- a/lib/sidekiq/pool/version.rb
+++ b/lib/sidekiq/pool/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Pool
-    VERSION = '1.3.0'
+    VERSION = '1.4.0'
   end
 end


### PR DESCRIPTION
@laurynas 

Making this optional since by our previous design it waited for all new children to get up before stopping old ones.