### PR TITLE
Dont wait for busy sidekiq when handling dead child

### DIFF
--- a/lib/sidekiq/pool/version.rb
+++ b/lib/sidekiq/pool/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Pool
-    VERSION = '1.4.0'
+    VERSION = '1.5.0'
   end
 end


### PR DESCRIPTION
@laurynas 

There is no necessity to wait for child to be busy when handling dead child, this will allow to handle upcoming signals faster.