### PR TITLE
Chdir to working directory in fork

### DIFF
--- a/lib/sidekiq/pool/version.rb
+++ b/lib/sidekiq/pool/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Pool
-    VERSION = '1.5.0'
+    VERSION = '1.5.1'
   end
 end


### PR DESCRIPTION
@laurynas 

Problem with chdir to working directory during testing I have found out that children that were killed were not starting due to removed old release.

Doing chdir inside fork as unicorn does https://github.com/defunkt/unicorn/blob/3dbbda30f02a40025abdee395fb0803985046db6/lib/unicorn/http_server.rb#L439

