### PR TITLE
Always change to working directory when starting new pool

### DIFF
--- a/lib/sidekiq/pool/cli.rb
+++ b/lib/sidekiq/pool/cli.rb
@@ -47,6 +47,7 @@ module Sidekiq
 
       def start_new_pool
         logger.info 'Starting new pool'
+        Dir.chdir(working_directory) if working_directory
         @settings = parse_config_file(@pool_config)
         @types = @settings[:workers]
         @types.each do |type|

--- a/lib/sidekiq/pool/version.rb
+++ b/lib/sidekiq/pool/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Pool
-    VERSION = '1.5.1'
+    VERSION = '1.5.2'
   end
 end


### PR DESCRIPTION
@laurynas 

Not completely sure but I hope this is the last case for defunct since this line:

```ruby
@settings = parse_config_file(@pool_config)
```

Expects file to be always present and if main process does not switch directories for a long time that initial directory might get removed due to 'old release' by capistrano. 