### PR TITLE
Reset child identity after fork

### DIFF
--- a/lib/sidekiq/pool/cli.rb
+++ b/lib/sidekiq/pool/cli.rb
@@ -183,7 +183,14 @@ module Sidekiq
 
           @self_write.close
           $0 = 'sidekiq starting'
-          options[:index] = @child_index++
+          @child_index += 1
+          options[:index] = @child_index
+
+          # reset child identity
+          @@process_nonce = nil
+          @@identity = nil
+          options[:identity] = identity
+
           run_child
         end
 


### PR DESCRIPTION
@ernestas-poskus @spajus @titas 

Fixes issue when single process is displayed in admin (broke since Sidekiq v4.2.0).