### PR TITLE
Copy On Write support

### DIFF
--- a/bin/sidekiq-pool
+++ b/bin/sidekiq-pool
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-# Quiet some warnings we see when running in warning mode:
-# RUBYOPT=-w bundle exec sidekiq-pool
 $TESTING = false
 
 require_relative '../lib/sidekiq/pool/cli'

--- a/lib/sidekiq/pool/version.rb
+++ b/lib/sidekiq/pool/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Pool
-    VERSION = '1.5.4'
+    VERSION = '1.6.0'
   end
 end


### PR DESCRIPTION
@laurynas @tomasv @tomaszulgis

When Sidekiq::Cli starts, it will boot rails first and only then fork the children. This way CoW support will kick in.

Code reload is similar to Unicorn, when HUP signal is received, children are transferred to QUIET mode, master is fork/exec'ed, thus new master process is spawned.

```
\-+- 66607 sidekiq-pool 1.6.0 core stopping
   |--- 66983 sidekiq 4.2.10 core [1 of 20 busy] stopping
   |--- 66994 sidekiq 4.2.10 core [1 of 20 busy] stopping
   |--- 66998 sidekiq 4.2.10 core [2 of 20 busy] stopping
   \-+- 69925 sidekiq-pool 1.6.0
     |--- 70186 sidekiq 4.2.10 core [0 of 20 busy]
     |--- 70194 sidekiq 4.2.10 core [0 of 20 busy]
     \--- 70202 sidekiq 4.2.10 core [0 of 20 busy]
```
Initiating process then terminates, leaving new pool running (with code and gem changes picked up)
```
\-+- 69925 sidekiq-pool 1.6.0
   |--- 70186 sidekiq 4.2.10 core [0 of 20 busy]
   |--- 70194 sidekiq 4.2.10 core [2 of 20 busy]
   \--- 70202 sidekiq 4.2.10 core [2 of 20 busy]
```